### PR TITLE
Ignore bash-compgen, to clean up git-status.

### DIFF
--- a/etc/bash_completion.d/.gitignore
+++ b/etc/bash_completion.d/.gitignore
@@ -1,1 +1,2 @@
+rip
 bash-compgen


### PR DESCRIPTION
After building morituri per the instructions in the README, up through `./autogen.sh`, do a `git status`. The output shows that the file `etc/bash_completion.d/bash-compgen` is untracked. `bash-compgen` is a generated file, and so it should be outside version control. Looking at `etc/bash_completion.d/.gitignore`, I see an entry for `rip` (which is created later, in this directory) but no entry for `bash-compgen`. This branch fixes that. 

In this branch, `git status` shows zero untracked files, both after `./authogen.sh`, and after `make`.

BTW this is my first contribution to someone else's project through github. If I'm doing it wrong, please educate me.
