### PR TITLE
Use os.path.join instead of hardcoded paths.

### DIFF
--- a/morituri/common/directory.py
+++ b/morituri/common/directory.py
@@ -34,7 +34,7 @@ class Directory(log.Loggable):
             path = os.path.join(directory, 'morituri.conf')
             self.info('Using XDG, configuration file is %s' % path)
         except ImportError:
-            path = os.path.expanduser('~/.moriturirc')
+            path = os.path.join(os.path.expanduser('~'), '.moriturirc')
             self.info('Not using XDG, configuration file is %s' % path)
         return path
 
@@ -45,7 +45,7 @@ class Directory(log.Loggable):
             path = BaseDirectory.save_cache_path('morituri')
             self.info('Using XDG, cache directory is %s' % path)
         except ImportError:
-            path = os.path.expanduser('~/.morituri/cache')
+            path = os.path.join(os.path.expanduser('~'), '.morituri', 'cache')
             if not os.path.exists(path):
                 os.makedirs(path)
             self.info('Not using XDG, cache directory is %s' % path)
@@ -68,7 +68,7 @@ class Directory(log.Loggable):
         except ImportError:
             pass
 
-        path = os.path.expanduser('~/.morituri/cache')
+        path = os.path.join(os.path.expanduser('~'), '.morituri', 'cache')
         if os.path.exists(path):
             self.info('From before XDG, read cache directory is %s' % path)
             paths.append(path)


### PR DESCRIPTION
It's my first commit.
It's better to use os.path.join to support system not using / as file separator.
