### PR TITLE
Compare AccurateRip to num tracks -1, as last track not being checked

### DIFF
--- a/morituri/rip/offset.py
+++ b/morituri/rip/offset.py
@@ -188,7 +188,7 @@ CD in the AccurateRip database."""
                             track, i))
                         count += 1
 
-                if count == len(table.tracks):
+                if count == len(table.tracks) - 1:
                     self._foundOffset(device, offset)
                     return 0
                 else:


### PR DESCRIPTION
It looks like when the for range in line 175 of offset.py was changed to stop the last track being changed, the subsequent comparison wasn't changed to allow for this on line 191.

This meant that the check will always never succeed as the number of tracks that matched the AccurateRip checksum will always be 1 less than the number of tracks.
