### PR TITLE
Convert drive path from unicode to str when calling cdio.Device (pycdio 0.19 / Arch Linux)

### DIFF
--- a/morituri/rip/offset.py
+++ b/morituri/rip/offset.py
@@ -188,7 +188,7 @@ CD in the AccurateRip database."""
                             track, i))
                         count += 1
 
-                if count == len(table.tracks):
+                if count == len(table.tracks) - 1:
                     self._foundOffset(device, offset)
                     return 0
                 else:


### PR DESCRIPTION
morituri and pycdio 0.19-1 seem to have some incompatibilities.

I am running under Arch Linux. I think the issue is that a unicode string is being passed to cdio.Device, when a normal python string is expected.

```
TypeError: in method 'open_cd', argument 1 of type 'char const *'
```

I think "char const *" translates to a normal python string in python2.

Note: I am not very familiar with unicode strings in python2, as I normally use python3 (strings and bytes).

Converting the path object passed to cdio.Device to a string (in rip/cd.py and common/drive.py) seems to fix the issue, I was able to successfully find drive offset and perform a rip.

Here is the full Trackback:

```
 rip cd rip
Traceback (most recent call last):
  File "morituri-0.2.0/bin/rip", line 35, in <module>
    sys.exit(main.main(sys.argv[1:]))
  File "morituri-0.2.0/morituri/rip/main.py", line 33, in main
    ret = c.parse(argv)
  File "morituri-0.2.0/morituri/rip/main.py", line 111, in parse
    logcommand.LogCommand.parse(self, argv)
  File "morituri-0.2.0/morituri/extern/command/command.py", line 385, in parse
    return self.subCommands[command].parse(args[1:])
  File "morituri-0.2.0/morituri/extern/command/command.py", line 385, in parse
    return self.subCommands[command].parse(args[1:])
  File "morituri-0.2.0/morituri/extern/command/command.py", line 309, in parse
    ret = self.handleOptions(self.options)
  File "morituri-0.2.0/morituri/rip/cd.py", line 111, in handleOptions
    info = drive.getDeviceInfo(self.parentCommand.options.device)
  File "morituri-0.2.0/morituri/common/drive.py", line 69, in getDeviceInfo
    device = cdio.Device(path)
  File "/usr/lib/python2.7/site-packages/cdio.py", line 341, in __init__
    self.open(source, driver_id, access_mode)
  File "/usr/lib/python2.7/site-packages/cdio.py", line 651, in open
    self.cd = pycdio.open_cd(source, driver_id, access_mode)
  File "/usr/lib/python2.7/site-packages/pycdio.py", line 967, in open_cd
    return _pycdio.open_cd(*args)
TypeError: in method 'open_cd', argument 1 of type 'char const *'
```

```
$ pacman -Q python2-pycdio
python2-pycdio 0.19-1
```
