### PR TITLE
Filenames from musicbrainz may contain invalid characters for windows filesystems

### DIFF
--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -264,7 +264,9 @@ class Program(log.Loggable):
         template = re.sub(r'%(\w)', r'%(\1)s', template)
 
         ret = os.path.join(outdir, template % v)
-        ret = ret.replace(':', ' -')
+        
+        # remove invalid chars for windows filesystems
+        ret = re.sub(r'[\?\|<>:"]', '', ret)
 
         return ret
 


### PR DESCRIPTION
The album and song names returned from musicbrainz sometimes contain characters that are not valid on windows filesystems like :<>"?|.

This could be an issue if ripping to windows filesystems or storing rips on a harddrive that has a windows filesystem or an mp3 player for example.

This patch just replaces them all, but maybe there is a better way.

Before:

```
rip cd rip --output-directory=.
Using configured read offset 102
Checking device /dev/sr0
CDDB disc id: 900af80a                        
MusicBrainz disc id IMQbpP7hYR3ssDOM6ubt56dp1nE-
MusicBrainz lookup URL http://mm.musicbrainz.org/bare/cdlookup.html?toc=1+10+210798+150+20329+44092+71162+89382+108381+125271+144536+166225+187270&tracks=10&id=IMQbpP7hYR3ssDOM6ubt56dp1nE-
Disc duration: 00:46:48.640, 10 audio tracks

Matching releases:

Artist  : David Guetta
Title   : Nothing but the Beat (Disc 2 of 2): Electronic Album
Duration: 00:46:45.000
URL     : http://musicbrainz.org/release/05b8c34d-e064-45cd-87e5-b870b7a6a8c3
Release : 05b8c34d-e064-45cd-87e5-b870b7a6a8c3
Type    : Album

Artist  : David Guetta
Title   : Nothing but the Beat (Deluxe Edition) (Disc 2 of 3): Electronic Album
Duration: 00:46:45.000
URL     : http://musicbrainz.org/release/53cd2e35-505e-4051-9b9d-e6bbf7d7ccda
Release : 53cd2e35-505e-4051-9b9d-e6bbf7d7ccda
Type    : Album

** Message: pygobject_register_sinkfunc is deprecated (GstObject)
Creating output directory ./album/David Guetta - Nothing but the Beat (Disc 2 of 2): Electronic Album
Traceback (most recent call last):
  File "/usr/bin/rip", line 39, in <module>
    sys.exit(main.main(sys.argv[1:]))
  File "/usr/lib/python2.7/site-packages/morituri/rip/main.py", line 45, in main
    ret = c.parse(argv)
  File "/usr/lib/python2.7/site-packages/morituri/rip/main.py", line 123, in parse
    logcommand.LogCommand.parse(self, argv)
  File "/usr/lib/python2.7/site-packages/morituri/extern/command/command.py", line 385, in parse
    return self.subCommands[command].parse(args[1:])
  File "/usr/lib/python2.7/site-packages/morituri/extern/command/command.py", line 385, in parse
    return self.subCommands[command].parse(args[1:])
  File "/usr/lib/python2.7/site-packages/morituri/extern/command/command.py", line 347, in parse
    ret = self.do(args)
  File "/usr/lib/python2.7/site-packages/morituri/rip/cd.py", line 140, in do
    self.doCommand()
  File "/usr/lib/python2.7/site-packages/morituri/rip/cd.py", line 282, in doCommand
    os.makedirs(dirname)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 22] Invalid argument: './album/David Guetta - Nothing but the Beat (Disc 2 of 2): Electronic Album'
```

After

```
rip cd rip
Using configured read offset 102
Checking device /dev/sr0
CDDB disc id: 900af80a                        
MusicBrainz disc id IMQbpP7hYR3ssDOM6ubt56dp1nE-
MusicBrainz lookup URL http://mm.musicbrainz.org/bare/cdlookup.html?toc=1+10+210798+150+20329+44092+71162+89382+108381+125271+144536+166225+187270&tracks=10&id=IMQbpP7hYR3ssDOM6ubt56dp1nE-
Disc duration: 00:46:48.640, 10 audio tracks

Matching releases:

Artist  : David Guetta
Title   : Nothing but the Beat (Disc 2 of 2): Electronic Album
Duration: 00:46:45.000
URL     : http://musicbrainz.org/release/05b8c34d-e064-45cd-87e5-b870b7a6a8c3
Release : 05b8c34d-e064-45cd-87e5-b870b7a6a8c3
Type    : Album

Artist  : David Guetta
Title   : Nothing but the Beat (Deluxe Edition) (Disc 2 of 3): Electronic Album
Duration: 00:46:45.000
URL     : http://musicbrainz.org/release/53cd2e35-505e-4051-9b9d-e6bbf7d7ccda
Release : 53cd2e35-505e-4051-9b9d-e6bbf7d7ccda
Type    : Album

** Message: pygobject_register_sinkfunc is deprecated (GstObject)
Creating output directory /share/EAC/album/David Guetta - Nothing but the Beat (Disc 2 of 2) Electronic Album
Ripping track 1 of 10: 01. David Guetta - The Alphabeat.flac
```

Thanks
