### PR TITLE
Run $PYTHON, not python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AS_AC_EXPAND(PLUGINSDIR, "\${libdir}/morituri/plugins")
 AC_MSG_NOTICE(Setting plugins directory to $PLUGINSDIR)
 
 dnl get git revision for installed.py.in
-AC_SUBST(REVISION, `python -c 'from morituri.configure import configure; print configure.revision'`)
+AC_SUBST(REVISION, `$PYTHON -c 'from morituri.configure import configure; print configure.revision'`)
 AC_MSG_NOTICE(Setting revision to $REVISION)
 
 dnl check for epydoc


### PR DESCRIPTION
This fixes the following error when running ./configure on a system where python refers to python3:

```
  File "<string>", line 1
    from morituri.configure import configure; print configure.revision
                                                            ^
SyntaxError: invalid syntax
configure: Setting revision to
```
