### PR TITLE
Also show the MusicBrainz lookup ID when retagging.

### DIFF
--- a/morituri/rip/image.py
+++ b/morituri/rip/image.py
@@ -124,6 +124,9 @@ class Retag(logcommand.LogCommand):
 
             mbdiscid = cueImage.table.getMusicBrainzDiscId()
             self.stdout.write('MusicBrainz disc id is %s\n' % mbdiscid)
+
+            self.stdout.write("MusicBrainz lookup URL %s\n" %
+                cueImage.table.getMusicBrainzSubmitURL())
             prog.metadata = prog.getMusicBrainz(cueImage.table, mbdiscid,
                 release=self.options.release_id)
 


### PR DESCRIPTION
This information can be quite helpful when a user does automated ripping
and in a second step retags the images to the correct release (using the
-R option).  Using this approach it sometimes turns out that the
specific needs to be added to MusicBrainz first or the disc id needs to
be added to an existent release.  In this case the user needs the lookup
id.
