### PR TITLE
Support dev on Eclipse and Pydev by .gitignoring two project files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ missing
 morituri.spec
 py-compile
 REVISION
+
+# For Python development using Eclipse IDE
+.project
+.pydevproject


### PR DESCRIPTION
This is a trivial change to .gitignore. It hides a project file `.project` used by the Eclipse IDE, and another file `.pydevproject` used by the PyDev extension for Eclipse. Ignoring these files makes the repository status clearer for developers using Eclipse, and shouldn't affect anyone else.
