### PR TITLE
Save MusicBrainz DiscID to tags.

### DIFF
--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -447,6 +447,7 @@ class Program(log.Loggable):
             disc = self.metadata.title
             mbidAlbum = self.metadata.mbid
             mbidTrackAlbum = self.metadata.mbidArtist
+            mbDiscId = self.metadata.discid
 
             if number > 0:
                 try:
@@ -510,6 +511,7 @@ class Program(log.Loggable):
                 ret["musicbrainz-artistid"] = mbidTrackArtist
                 ret["musicbrainz-albumid"] = mbidAlbum
                 ret["musicbrainz-albumartistid"] = mbidTrackAlbum
+                ret["musicbrainz-discid"] = mbDiscId
 
         # FIXME: gst.TAG_ISRC
 

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -123,6 +123,8 @@ class _CD(logcommand.LogCommand):
             "full table's AR URL %s differs from toc AR URL %s" % (
             self.itable.getAccurateRipURL(), self.ittoc.getAccurateRipURL())
 
+        self.program.metadata.discid = self.ittoc.getMusicBrainzDiscId()
+
         # result
 
         self.program.result.cdrdaoVersion = cdrdao.getCDRDAOVersion()


### PR DESCRIPTION
Probably needs some tests for this and also some more testing than what I've done (ie., I've just tested that it works on my system).

Rationale:
We already calculate the DiscID for looking up against the MusicBrainz database and currently just "throw it away" afterwards. Since morituri ejects the media, I currently have to re-insert it and tell Picard to lookup the disc if I want to have the DiscID saved to the files. (If I open up Picard by giving it the files directly, I also have to deassociate the files with the release from the MBID and remove the release from Picard's view to enable it to include the DiscID in its release information.)
