### PR TITLE
Show morituri version in cue and update TODO.

### DIFF
--- a/TODO
+++ b/TODO
@@ -5,10 +5,6 @@ TODO:
 - store drive features in a database
 - try http://www.ime.usp.br/~pjssilva/secure-cdparanoia.py and see if it
   is better at handling some bad cd's
-- .cue file:
-  - add version to morituri comment
-  - add DATE and CATALOG and PERFORMER and TITLE to top of cue
-  - add TITLE AND PERFORMER to each track
 - change format to be %2d - %performer by default
 - at least mention the data track somewhere in the log
 - check pregaps more than once, to see if results are consistent, or with

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -29,6 +29,7 @@ import urllib
 import urlparse
 
 from morituri.common import common, log
+from morituri.configure import configure
 
 # FIXME: taken from libcdio, but no reference found for these
 
@@ -542,7 +543,7 @@ class Table(object, log.Loggable):
 
         assert self.hasTOC(), "Table does not represent a full CD TOC"
         lines.append('REM DISCID %s' % self.getCDDBDiscId().upper())
-        lines.append('REM COMMENT "%s"' % program)
+        lines.append('REM COMMENT "%s %s"' % (program, configure.version))
 
         if self.catalog:
             lines.append("CATALOG %s" % self.catalog)


### PR DESCRIPTION
The cue file comment now reads:
REM COMMENT "Morituri 0.2.2.1"
where 0.2.2.1 is whatever configure.version shows, from morituri.configure.

The other two TODO lines were already implemented.
