### PR TITLE
use offset when caching TOC info

### DIFF
--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -108,7 +108,7 @@ class _CD(logcommand.LogCommand):
 
         self.itable = self.program.getTable(self.runner,
             self.ittoc.getCDDBDiscId(),
-            self.ittoc.getMusicBrainzDiscId(), self.device)
+            self.ittoc.getMusicBrainzDiscId(), self.device, self.options.offset)
 
         assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
             "full table's id %s differs from toc id %s" % (


### PR DESCRIPTION
Forces recalculation of the TOC info when using a drive with a
different offset.
