### PR TITLE
Inform user when rip offset is not saved when running 'rip offset find'

### DIFF
--- a/morituri/rip/offset.py
+++ b/morituri/rip/offset.py
@@ -239,6 +239,7 @@ CD in the AccurateRip database."""
 
         info = drive.getDeviceInfo(device)
         if not info:
+            self.stdout.write('Offset not saved: Could not get device info (requires pycdio).\n')
             return
 
         self.stdout.write('Adding read offset to configuration file.\n')


### PR DESCRIPTION
This confused me when finding the offset for my drive. I thought the offset was saved as no message was displayed, but no configuration file was present. I had to go through the source code to find out why. I think this message will help users in this scenario.
