### PR TITLE
improve configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,32 @@ when possible.
 It lives in `$XDG_CONFIG_HOME/morituri/morituri.conf`
 
 The configuration file follows python's ConfigParser syntax.
-There is a "main" section and zero or more sections starting with "drive:"
 
-- main section:
+The possible sections are:
+
+- main section: [main]
   - `path_filter_fat`: whether to filter path components for FAT file systems
   - `path_filter_special`: whether to filter path components for special
                            characters
 
-- drive section:
+- drive section: [drive:IDENTIFIER], one for each configured drive
   All these values are probed by morituri and should not be edited by hand.
   - `defeats_cache`: whether this drive can defeat the audio cache
   - `read_offset`: the read offset of the drive
+
+- rip comand section: [rip.COMMAND.SUBCOMMAND]
+  Can be used to change the command options default values.
+
+Example section to configure "rip cd rip" defaults:
+
+   [rip.cd.rip]
+    unknown = True
+    output_directory = ~/My Music
+    track_template = new/%%A/%%y - %%d/%%t - %%n
+    disc_template = %(track_template)s
+    profile = flac
+
+Note: to get a literal '%' character it must be doubled.
 
 CONTRIBUTING
 ------------

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -208,11 +208,13 @@ Log files will log the path to tracks relative to this directory.
             help="output directory; will be included in file paths in result "
                 "files "
                 "(defaults to absolute path to current directory; set to "
-                "empty if you want paths to be relative instead) ")
+                "empty if you want paths to be relative instead; "
+                "configured value: %default) ")
         self.parser.add_option('-W', '--working-directory',
             action="store", dest="working_directory",
             help="working directory; morituri will change to this directory "
-                "and files will be created relative to it when not absolute ")
+                "and files will be created relative to it when not absolute "
+                "(configured value: %default) ")
 
         rcommon.addTemplate(self)
 
@@ -223,8 +225,8 @@ Log files will log the path to tracks relative to this directory.
 
         self.parser.add_option('', '--profile',
             action="store", dest="profile",
-            help="profile for encoding (default '%s', choices '%s')" % (
-                default, "', '".join(encode.PROFILES.keys())),
+            help="profile for encoding (default '%%default', choices '%s')" % (
+                "', '".join(encode.PROFILES.keys())),
             default=default)
         self.parser.add_option('-U', '--unknown',
             action="store_true", dest="unknown",

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -256,6 +256,11 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
                         options.offset)
         if self.options.output_directory is None:
             self.options.output_directory = os.getcwd()
+        else:
+            self.options.output_directory = os.path.expanduser(self.options.output_directory)
+
+        if self.options.working_directory is not None:
+            self.options.working_directory = os.path.expanduser(self.options.working_directory)
 
         if self.options.logger:
             try:


### PR DESCRIPTION
Automatically override a command default options with the corresponding configuration file section.

So for example, a valid section for the 'rip cd rip' command would look like this:

```
[rip.cd.rip]
unknown = True
output_directory = ~/My Music
track_template = new/%%A/%%y - %%d/%%t - %%n
disc_template = %(track_template)s
profile = flac
```

Note: I also tweaked 'rip cd rip --help' output, and updated the README section about the configuration file syntax.
