### PR TITLE
Add experimental overread support (lead-out)

### DIFF
--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -558,7 +558,7 @@ class Program(log.Loggable):
         return ret
 
     def ripTrack(self, runner, trackResult, offset, device, profile, taglist,
-        what=None):
+        overread, what=None):
         """
         Ripping the track may change the track's filename as stored in
         trackResult.
@@ -582,7 +582,7 @@ class Program(log.Loggable):
             what='track %d' % (trackResult.number, )
 
         t = cdparanoia.ReadVerifyTrackTask(trackResult.filename,
-            self.result.table, start, stop,
+            self.result.table, start, stop, overread,
             offset=offset,
             device=device,
             profile=profile,

--- a/morituri/program/cdparanoia.py
+++ b/morituri/program/cdparanoia.py
@@ -216,8 +216,8 @@ class ReadTrackTask(log.Loggable, task.Task):
 
     _MAXERROR = 100 # number of errors detected by parser
 
-    def __init__(self, path, table, start, stop, offset=0, device=None,
-        action="Reading", what="track"):
+    def __init__(self, path, table, start, stop, overread, offset=0,
+        device=None, action="Reading", what="track"):
         """
         Read the given track.
 
@@ -248,6 +248,7 @@ class ReadTrackTask(log.Loggable, task.Task):
         self._parser = ProgressParser(start, stop)
         self._device = device
         self._start_time = None
+        self._overread = overread
 
         self._buffer = "" # accumulate characters
         self._errors = []
@@ -278,8 +279,12 @@ class ReadTrackTask(log.Loggable, task.Task):
             stopTrack, stopOffset)
 
         bufsize = 1024
-        argv = ["cdparanoia", "--stderr-progress",
-            "--sample-offset=%d" % self._offset, ]
+        if self._overread:
+            argv = ["cdparanoia", "--stderr-progress",
+                "--sample-offset=%d" % self._offset, "--force-overread", ]
+        else:
+            argv = ["cdparanoia", "--stderr-progress",
+                "--sample-offset=%d" % self._offset, ]
         if self._device:
             argv.extend(["--force-cdrom-device", self._device, ])
         argv.extend(["%d[%s]-%d[%s]" % (
@@ -422,8 +427,8 @@ class ReadVerifyTrackTask(log.Loggable, task.MultiSeparateTask):
     _tmpwavpath = None
     _tmppath = None
 
-    def __init__(self, path, table, start, stop, offset=0, device=None,
-                 profile=None, taglist=None, what="track"):
+    def __init__(self, path, table, start, stop, overread, offset=0,
+                 device=None, profile=None, taglist=None, what="track"):
         """
         @param path:    where to store the ripped track
         @type  path:    str
@@ -460,10 +465,10 @@ class ReadVerifyTrackTask(log.Loggable, task.MultiSeparateTask):
 
         self.tasks = []
         self.tasks.append(
-            ReadTrackTask(tmppath, table, start, stop,
+            ReadTrackTask(tmppath, table, start, stop, overread,
                 offset=offset, device=device, what=what))
         self.tasks.append(checksum.CRC32Task(tmppath))
-        t = ReadTrackTask(tmppath, table, start, stop,
+        t = ReadTrackTask(tmppath, table, start, stop, overread,
             offset=offset, device=device, action="Verifying", what=what)
         self.tasks.append(t)
         self.tasks.append(checksum.CRC32Task(tmppath))

--- a/morituri/result/logger.py
+++ b/morituri/result/logger.py
@@ -69,6 +69,12 @@ class MorituriLogger(result.Logger):
 
         lines.append("Read offset correction: %d" %
             ripResult.offset)
+        overread = "Unknown"
+        if ripResult.overread is True:
+            overread = "Yes (Lead-Out)"
+        if ripResult.overread is False:
+            overread = "No"
+        lines.append("Overread: %s" % overread)
         lines.append("")
 
         # toc

--- a/morituri/result/result.py
+++ b/morituri/result/result.py
@@ -93,6 +93,7 @@ class RipResult:
     """
 
     offset = 0
+    overread = None
     table = None
     artist = None
     title = None

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -203,6 +203,13 @@ Log files will log the path to tracks relative to this directory.
         self.parser.add_option('-o', '--offset',
             action="store", dest="offset",
             help="sample read offset (defaults to configured value, or 0)")
+        self.parser.add_option('-x', '--force-overread',
+            action="store_true", dest="overread",
+            help="Force overreading into the lead-out portion of the disc. "
+                "Works only if the patched cdparanoia package is installed "
+                "and the drive supports this feature. "
+                "The default value is: %default",
+            default=False)
         self.parser.add_option('-O', '--output-directory',
             action="store", dest="output_directory",
             help="output directory; will be included in file paths in result "
@@ -281,6 +288,7 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
         self.program.setWorkingDirectory(self.options.working_directory)
         self.program.outdir = self.options.output_directory.decode('utf-8')
         self.program.result.offset = int(self.options.offset)
+        self.program.result.overread = self.options.overread
 
         ### write disc files
         disambiguate = False
@@ -377,6 +385,7 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
                             device=self.parentCommand.options.device,
                             profile=profile,
                             taglist=self.program.getTagList(number),
+                            overread=self.options.overread,
                             what='track %d of %d%s' % (
                                 number, len(self.itable.tracks), extra))
                         break

--- a/morituri/rip/offset.py
+++ b/morituri/rip/offset.py
@@ -218,7 +218,7 @@ CD in the AccurateRip database."""
 
         t = cdparanoia.ReadTrackTask(path, table,
             table.getTrackStart(track), table.getTrackEnd(track),
-            offset=offset, device=self.options.device)
+            overread=False, offset=offset, device=self.options.device)
         t.description = 'Ripping track %d with read offset %d' % (
             track, offset)
         runner.run(t)


### PR DESCRIPTION
This commit introduces experimental overread support for morituri. The
feature can be manually enabled through the command line switch `-x` or
`--force-overread`.

I’ve not tested it using a capable drive so I don’t know if it works as
expected.

The morituri log file should correctly report whether the rip was done
with the overread switch set or not (note that this does not imply that
the drive used is capable of overreading).

More informations are available through the integrated help.
